### PR TITLE
Add flatpak-external-data-checker integration

### DIFF
--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -34,7 +34,16 @@
                     "type": "git",
                     "url": "https://gitlab.com/libosinfo/osinfo-db.git",
                     "commit": "d316eee8d82a28664d28bb3fa0c889cd05985c0e",
-                    "tag": "v20210215"
+                    "tag": "v20210215",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.com/api/v4/projects/libosinfo%2Fosinfo-db/repository/tags",
+                        "tag-query": "first | .name",
+                        "commit-query": "first | .commit.id",
+                        "timestamp-query": "first | .commit.committed_date",
+                        "version-query": "$tag | sub(\"^[vV]\"; \"\")",
+                        "is-main-source": true
+                    }
                 }
             ]
         }

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -33,8 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/libosinfo/osinfo-db.git",
-                    "commit": "d316eee8d82a28664d28bb3fa0c889cd05985c0e",
-                    "tag": "v20210215",
+                    "commit": "2fe8b130460fdd51e2942f61c1cfa8dbfe82879b",
+                    "tag": "v20210312",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://gitlab.com/api/v4/projects/libosinfo%2Fosinfo-db/repository/tags",

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -1,39 +1,39 @@
 {
-    "id" : "org.gnome.Boxes.Extension.OsinfoDb",
-    "runtime" : "org.gnome.Boxes",
-    "runtime-version" : "stable",
-    "sdk" : "org.gnome.Sdk//3.38",
-    "build-extension" : true,
-    "separate-locales" : false,
-    "appstream-compose" : false,
-    "modules" : [
+    "id": "org.gnome.Boxes.Extension.OsinfoDb",
+    "runtime": "org.gnome.Boxes",
+    "runtime-version": "stable",
+    "sdk": "org.gnome.Sdk//3.38",
+    "build-extension": true,
+    "separate-locales": false,
+    "appstream-compose": false,
+    "modules": [
         {
-            "name" : "appdata",
-            "buildsystem" : "simple",
-            "build-commands" : [
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml",
                 "appstream-compose --basename=org.gnome.Boxes.Extension.OsinfoDb --prefix=${FLATPAK_DEST} --origin=flatpak org.gnome.Boxes.Extension.OsinfoDb"
             ],
-            "sources" : [
+            "sources": [
                 {
-                    "type" : "file",
-                    "path" : "org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml"
+                    "type": "file",
+                    "path": "org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml"
                 }
             ]
         },
         {
-            "name" : "osinfo-db",
-            "buildsystem" : "simple",
+            "name": "osinfo-db",
+            "buildsystem": "simple",
             "builddir": true,
-            "build-commands" : [
+            "build-commands": [
                 "make",
                 "osinfo-db-import --dir /app/share/osinfo/ osinfo-db-*.tar.xz"
             ],
-            "sources" : [
+            "sources": [
                 {
-                    "type" : "git",
-                    "url" : "https://gitlab.com/libosinfo/osinfo-db.git",
-                    "branch" : "d316eee8d82a28664d28bb3fa0c889cd05985c0e"
+                    "type": "git",
+                    "url": "https://gitlab.com/libosinfo/osinfo-db.git",
+                    "branch": "d316eee8d82a28664d28bb3fa0c889cd05985c0e"
                 }
             ]
         }

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -33,7 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/libosinfo/osinfo-db.git",
-                    "branch": "d316eee8d82a28664d28bb3fa0c889cd05985c0e"
+                    "commit": "d316eee8d82a28664d28bb3fa0c889cd05985c0e",
+                    "tag": "v20210215"
                 }
             ]
         }

--- a/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
+++ b/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
@@ -8,4 +8,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <update_contact>felipeborges_AT_gnome.org</update_contact>
+  <releases>
+    <release version="20210312" date="2021-03-03"/>
+  </releases>
 </component>


### PR DESCRIPTION
With these changes, a pull request will be automatically opened whenever a new tag is pushed to https://gitlab.com/libosinfo/osinfo-db, updating the manifest and adding the new version number to the metainfo.