### PR TITLE
Update osinfo-db and gnome SDK

### DIFF
--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -33,8 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/libosinfo/osinfo-db.git",
-                    "commit": "715c0385f4d020c687eb5fc0802ce632d753f728",
-                    "tag": "v20231027",
+                    "commit": "107dd4f4e22bfc3830497e377964175414d8f4e7",
+                    "tag": "v20231215",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://gitlab.com/api/v4/projects/libosinfo%2Fosinfo-db/repository/tags",

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -2,7 +2,7 @@
     "id": "org.gnome.Boxes.Extension.OsinfoDb",
     "runtime": "org.gnome.Boxes",
     "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//43",
+    "sdk": "org.gnome.Sdk//45",
     "build-extension": true,
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
+++ b/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
@@ -9,6 +9,7 @@
   <project_license>GPL-2.0+</project_license>
   <update_contact>felipeborges_AT_gnome.org</update_contact>
   <releases>
+    <release version="20231215" date="2023-12-15"/>
     <release version="20231027" date="2023-10-27"/>
     <release version="20230719" date="2023-07-06"/>
     <release version="20230518" date="2023-05-18"/>


### PR DESCRIPTION
- Update osinfo-db.git to tag `v20231215`
- Update gnome sdk to 44 (as 43 is EOL)